### PR TITLE
New design

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,8 +66,6 @@ plugins:
           sv: Svenska
 
 extra:
-  version:
-    provider: mike
   alternate:
     - name: Default (en)
       link: ./

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,21 +1,10 @@
 ---
-site_name: 'Rocky Linux Documentation'
+site_name: 'Documentation'
 site_url: 'https://docs.rockylinux.org'
 docs_dir: 'docs/docs'
 repo_url: https://github.com/rocky-linux/documentation
 repo_name: rocky-linux/documentation
-edit_uri: 'edit/main/docs/'
-
-nav:
-    - Table of Contents: index.md
-    - Guides:
-        - ... | guides/**/
-    - Books:
-        - ... | books/**/
-    - Labs:
-        - ... | labs/**/
-    - Release Notes:
-        - ... | release_notes/*.md
+edit_uri: ''
 
 theme:
   name: material
@@ -26,19 +15,20 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - search.suggest
   logo: assets/logo.png
-  favicon: assets/logo.png
+  favicon: assets/favicon.png
   palette:
     - scheme: default
       media: "(prefers-color-scheme: light)"
       toggle:
-        icon: material/weather-sunny
+        icon: material/weather-night
         name: Switch to dark mode
       primary: black
     - scheme: slate
       media: "(prefers-color-scheme: dark)"
       toggle:
-        icon: material/weather-night
+        icon: material/weather-sunny
         name: Switch to light mode
       primary: black
 
@@ -55,26 +45,55 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.keys
   - pymdownx.tabbed
+  - pymdownx.details
+  - pymdownx.tasklist
   - footnotes
   - def_list
-  - pymdownx.tasklist
   - meta
 
 plugins:
   - search
-  - localsearch
   - awesome-pages
   - i18n:
       default_language: en
       languages:
-        en: English
-        fr: Français
-        es: Español
-        jp: 日本語
-        zh_CN: 简体中文
-        sv: Svenska
+          en: English
+          de: Deutsch
+          fr: Français
+          es: Español
+          jp: 日本語
+          zh_CN: 简体中文
+          sv: Svenska
 
-extra: 
+extra:
+  version:
+    provider: mike
+  alternate:
+    - name: Default (en)
+      link: ./
+      lang: en
+    - name: English
+      link: ./en/
+      lang: en
+    - name: Français
+      link: ./fr/
+      lang: fr
+    - name: Deutsch
+      link: ./de/
+      lang: de
+    - name: Español
+      link: ./es/
+      lang: es
+    - name: 日本語
+      link: ./jp/
+      lang: jp
+    - name: 简体中文
+      link: ./zh_CN/
+      lang: zh_CN
+    - name: Svenska
+      link: ./sv/
+      lang: sv
+
   social:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/rocky_linux
@@ -84,5 +103,6 @@ extra:
       link: https://git.rockylinux.org
     - icon: material/home
       link: https://rockylinux.org
+
 
 copyright: Copyright &copy; 2021 The Rocky Enterprise Software Foundation

--- a/theme/assets/stylesheets/extra.css
+++ b/theme/assets/stylesheets/extra.css
@@ -33,3 +33,11 @@
 }
 
 .md-sidebar--primary .md-nav__link { display: flex; justify-content: space-between }
+
+/*
+Override reduced font size in admonitions and collapsible sections back to body size
+ */
+
+.md-typeset .admonition, .md-typeset details {
+    font-size: .8rem;
+}


### PR DESCRIPTION
These are the changes to the MkDocs level required to support the new navigation model which I and @sspencerwire have been working on.

## Changes

1. The site name which shows in top menu bar shortened because well versioning goes like the long title blocks the version widget
2. Nav section removed - it is now being done by .pages files in content
3. I took of the edit uri because, realistically, no-one edits content directly to GitHub, so having the edit icon there causes confusion
4. The dark/light theme switcher was the wrong way round, if the light theme is active the icon should show the dark icon to switch to dark mode and vice-versa
5. I added one Python markdown extensions which is useful and is now being used in the docs
6. Changed the favicon to the standard dark green favicon, the existing was using the large white png logo
7. Added extras to make language selection more clear and added 'en' as one of the language choices.
8. Materials for MkDocs was overriding the body text size for admonitions & collapsable blocks to a smaller font I overrode that so text now displays the same as the body text.