### PR TITLE
fix: add mkdocs-redirects as the redirect key is deprecated in mkdocs…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,10 @@ plugins:
           jp: 日本語
           zh_CN: 简体中文
           sv: Svenska
+  - redirects:
+      redirect_maps:
+        'guides/add_mirror_manager.md': 'guides/mirror_management/add_mirror_manager.md'
+        'guides/add_mirror_manager': 'guides/mirror_management/add_mirror_manager.md'
 
 extra:
   alternate:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ mkdocs
 mkdocs-material
 mkdocs-localsearch
 mkdocs-awesome-pages-plugin
+mkdocs-redirects
 git+https://github.com/ultrabug/mkdocs-static-i18n.git@issue_37


### PR DESCRIPTION
> widyono
> 11:41
> 
> I'm getting 404 for https://docs.rockylinux.org/guides/add_mirror_manager/, is that still the valid link?
> 
> 	
> lumarel
> 11:44
> Looks like the index got changed, it's here now: 
> https://docs.rockylinux.org/guides/mirror_management/add_mirror_manager/




This doc, in particular, is pretty important. I think that we should have a redirect setup for the change of location.