### PR TITLE
Restructure - moving documentation content from docs/docs/ to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Rocky Linux Documentation Generator
+
+This repository holds the [MkDocs](https://www.mkdocs.org) documentation generator configuration files for building the [Rocky Linux](https://rockylinux.org) documentation website — [https://docs.rockylinux.org](https://docs.rockylinux.org).
+
+The repository and the information within will typically only be used by the Rocky Linux website administrators.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 ---
 site_name: 'Documentation'
 site_url: 'https://docs.rockylinux.org'
-docs_dir: 'docs/docs'
+docs_dir: 'docs'
 repo_url: https://github.com/rocky-linux/documentation
 repo_name: rocky-linux/documentation
 edit_uri: ''
@@ -17,7 +17,7 @@ theme:
     - navigation.top
     - search.suggest
   logo: assets/logo.png
-  favicon: assets/logo.png
+  favicon: assets/favicon.png
   palette:
     - scheme: default
       media: "(prefers-color-scheme: light)"
@@ -61,13 +61,10 @@ plugins:
           de: Deutsch
           fr: Français
           es: Español
-          jp: 日本語
-          zh_CN: 简体中文
+          ja: 日本語
+          pt: Português
+          zh: 简体中文
           sv: Svenska
-  - redirects:
-      redirect_maps:
-        'guides/add_mirror_manager.md': 'guides/mirror_management/add_mirror_manager.md'
-        'guides/add_mirror_manager': 'guides/mirror_management/add_mirror_manager.md'
 
 extra:
   alternate:
@@ -87,11 +84,14 @@ extra:
       link: ./es/
       lang: es
     - name: 日本語
-      link: ./jp/
-      lang: jp
+      link: ./ja/
+      lang: ja
+    - name: Português
+      link: ./pt/
+      lang: pt
     - name: 简体中文
-      link: ./zh_CN/
-      lang: zh_CN
+      link: ./zh/
+      lang: zh
     - name: Svenska
       link: ./sv/
       lang: sv

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,10 @@ plugins:
           pt: Português
           zh: 简体中文
           sv: Svenska
+  - redirects:
+      redirect_maps:
+        'guides/add_mirror_manager.md': 'guides/mirror_management/add_mirror_manager.md'
+        'guides/add_mirror_manager': 'guides/mirror_management/add_mirror_manager.md'
 
 extra:
   alternate:

--- a/scripts/attribution.sh
+++ b/scripts/attribution.sh
@@ -1,0 +1,116 @@
+#!/bin/bash 
+
+# @author Neil Hanlon <neil@rockylinux.org> 
+# @date 2021-02-26 
+# @desc This script takes an input filename and returns as output a
+# yaml-compatible document to be appended into file metadata for attribution of
+# contributors to documentation articles
+
+function debug() {
+    # @param    $1  - string to be formatted as a debug if debug is set
+    if [[ $DEBUG ]]; then
+        printf "[DEBUG] %s %s\n" $(date +'%Y-%m-%d %H:%M:%S') "$1"
+    fi
+}
+
+function format_contributor() {
+    # @param    commiter    - the contributor's detail string (from locals)
+    # @return   output      - the formatted string
+    output=$(echo ${commiter} | awk -F\; '{print $2}')
+}
+
+function format() {
+    # @param    contributor_set       - the array to iterate on and output; it
+    #                                   should be sorted by commit date, 
+    #                                   ascending.
+    # @stdout   formatted text        - formatted output in yaml
+
+    # Add a yaml document header
+    echo '---'
+    # The author is the first one to commit
+    printf "author: '%s'\n" "${contributor_set[0]}"
+
+    # Everyone else is a contributor. As long as there is more than one
+    # commiter, loop through them and append them to the line.
+    printf "contributors: '"
+    if [[ "${#contributor_set[@]}" -ge 1 ]]; then 
+        for c in "${contributor_set[@]:1}"; do
+            if [[ "$c" != "${contributor_set[-1]}" ]]; then
+                printf "%s, " "$c"
+            else
+                printf "%s" "$c"
+            fi
+        done 
+    fi
+    printf "'\n"
+
+    printf "%s\n" "$(awk '// {print}' $file)"
+
+    # Add the yaml document footer
+    printf "...\n"
+}
+
+function process_contributors() {
+    ##
+    # This function takes an indexed array of formatted git hashes, processes
+    # them to make them unique, and returns a yaml-compliant output to be used
+    # in documentation headers/metadata.
+    #
+    # @param $1 - the name of an indexed array to walk
+    ##
+    local -n ref=$1
+
+    # format looks like this, so we change IFS and re-read to make each element
+    # of the array a commiter; With whitespace because I hate bash
+    # d20a845;Full Name;email@example.com| 5e31b956;Another Person;email2@example.com|
+    _IFS=$IFS
+    IFS='|'
+    local -a commiters=($ref)
+    IFS=$_IFS
+
+
+    # Loop through every commiter; Skip if it is empty or if the formatted
+    # version is already contained in the output array. (Unique it)
+    local -a contributor_set # Ordered Set containing contributors for the file
+
+    local commiter
+    local -a output=()
+    for commiter in "${commiters[@]}"; do
+        format_contributor # returns formatted version in $output
+        if [[ $commiter == '' || "${contributor_set[*]}" =~ $output ]]; then
+            continue;
+        else
+            contributor_set=("${output}" "${contributor_set[@]}")
+        fi
+    done
+
+    # Call the format function to process $contributor_set and output
+    format
+}
+
+
+file="$1"
+
+# Try to find the original author of this file
+cmd="git log --pretty=format:%h;%an;%ae|"
+
+# Run the git log twice. Once as --follow, once without.
+# --follow returns the same output as no-follow if the file has not been renamed
+# but if the file is renamed, --follow returns ONLY the commits associated with
+# the linked git object in the tree, and no-follow returns the current-HEAD file
+mapfile -t follow < <(${cmd} --follow ${file})
+mapfile -t normal < <(${cmd} ${file})
+
+# Check to see if the command outputs are identical, and if so, just use one of
+# them to assign attribution
+if [[ "${follow[@]}" == "${normal[@]}" ]]; then
+    process_contributors follow
+else
+    # If the command outputs are not identical, then concatenate the arrays
+    # together, preserving order by keeping the older (follow) commits first.
+    combined=("${follow[@]}" "${normal[@]}")
+    process_contributors combined[@] # Nondimensionalize the array, as expected
+                                     # by the called function
+fi
+
+exit 0


### PR DESCRIPTION
## Notes

1. This PR **_must_** be merged simultaneously with the PR for the documentation repository.
See https://github.com/rocky-linux/documentation/pull/296
2. Can I request that, as standard, GitHub's '[Squash and Merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits)' for pull request commits be used to squash commits into one.
3. The PR #30 can, and should, be deleted as this PR subsumes it.
4. PR #30 also had a reversal for change in a previous PR, the `edit_uri:` setting. This was previously changed to remove the edit URI after explanation, discussion and agreement with everyone as it provides no value to have it and fails for all website visitors. I'm not sure why it was included back in PR #30, a mistake perhaps.

## Changes

1. Folder 'scripts' moved from documentation/main to this repository, so (from perspective of docs.rockylinux.org repository) moved from [root]/docs/scripts to [root]/scripts
2. I added a README.md file as there was not one. I did not think it could hurt. If one is not desired it can be deleted.
3. As discussed with everyone `docs_dir: 'docs/docs'` changes to `docs_dir: 'docs'`.
4. Added new locale and language selection for Portuguese (Português)
5. Corrected locale code for Japanese and Chinese to those required by Luna & Material for MkDocs.
4. In a previous PR it was explained and discussed that the favicon was using the same graphic as the web page header logo. This made the favicon essentially invisible (this was mentioned in my recent discussion document). It was corrected but then subsequently another PR changed it back to the (invisible) light coloured logo. I believe that PR was a mistake (?) and I have reversed the reversal.


