### PR TITLE
Add tagging to docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+        args: [--unsafe]
+    -   id: check-added-large-files

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,7 @@ plugins:
   - redirects:
       redirect_maps:
         'guides/add_mirror_manager.md': 'guides/mirror_management/add_mirror_manager.md'
-  - tags      
+  - tags
 
 extra:
   alternate:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ plugins:
   - redirects:
       redirect_maps:
         'guides/add_mirror_manager.md': 'guides/mirror_management/add_mirror_manager.md'
+  - tags      
 
 extra:
   alternate:


### PR DESCRIPTION
* This is a simple change to the mkdocs.yml file that enables tagging.
The plugin is available by default in Mkdocs Material