### PR TITLE
Add bare pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+        args: [--unsafe]
+    -   id: check-added-large-files


### PR DESCRIPTION
Need to pass --unsafe to check-yaml because the mkdocs uses custom YAML
Tags which aren't able to be properly parsed

Fixes #37