### PR TITLE
Change back to upstream material-mkdocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-localsearch
-# nhanlon(2022-08-25) using my fork of mkdocs-material to get around search issue for the time being
-git+https://github.com/NeilHanlon/mkdocs-material.git@master
+mkdocs-material
 mkdocs-redirects
 mkdocs-static-i18n
 jieba


### PR DESCRIPTION
* Neil had temp fixed a search issue using his own private repository,
however this has now been fixed upstream, using a different method, so
we need to go back to the official plugin.
* We wanted to leave the other changes made by Neil in his original PR,
so we did **NOT** want to revert his change completely.
* This PR simply adds back the "official" mkdocs-material upstream
plugin