### PR TITLE
Re-enable editing pencil on doc pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ theme:
   font:
     text: Red Hat Text
   icon:
-    edit: material/pencil  
+    edit: material/pencil
   features:
     - content.action.edit
     - navigation.tabs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,10 @@ theme:
   custom_dir: theme
   font:
     text: Red Hat Text
+  icon:
+    edit: material/pencil  
   features:
+    - content.action.edit
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top


### PR DESCRIPTION
After the update to 9.0.0, changes in the theme section required.