### PR TITLE
fix: workflow_dispatch, not -dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-  workflow-dispatch:
+  workflow_dispatch:
   repository_dispatch:
     types: [remote_deploy]
 


### PR DESCRIPTION
### TL;DR
Fix typo in GitHub Actions workflow file to correctly trigger the deployment workflow on workflow dispatch.

### What changed?
Corrected `workflow-dispatch` to `workflow_dispatch` in the `.github/workflows/deploy.yml` file.
