### PR TITLE
fix: need to checkout first

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,8 @@ jobs:
     environment: production
     steps:
 
+      - uses: actions/checkout@v4
+
       - uses: actions/cache/restore@v4
         id: docs-cache
         with:


### PR DESCRIPTION
This PR updates the deployment workflow to include an additional step for checking out the repository using `actions/checkout@v4`. This step is added before restoring the cache to ensure the workflow has access to the repository files needed for deployment.


