### PR TITLE
Add FASTLY_API_TOKEN environment variable to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           verbose: true
           project_directory: compute-js
+        env:
+          FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
 
       - name: Deploy Compute Package
         uses: fastly/compute-actions/deploy@v6


### PR DESCRIPTION
This pull request introduces the FASTLY_API_TOKEN environment variable to the deployment workflow configuration (.github/workflows/deploy.yml). This variable is required for deployment with Fastly services and is sourced from GitHub secrets.