### PR TITLE
fix: update event type in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
       - main
   workflow_dispatch:
   repository_dispatch:
-    types: [remote_deploy]
+    types: [deploy]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the type of repository_dispatch event in the deploy workflow from 'remote_deploy' to 'deploy'. This change ensures that the correct event type is used to trigger the workflow.