### PR TITLE
Add navigation buttons to documentation pages

### DIFF
--- a/configs/mkdocs.full.yml
+++ b/configs/mkdocs.full.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share

--- a/configs/mkdocs.minimal.yml
+++ b/configs/mkdocs.minimal.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share

--- a/configs/mkdocs.yml
+++ b/configs/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share


### PR DESCRIPTION
   ## Summary
   Adds Previous/Next navigation buttons to documentation pages to improve user experience when reading through sequential content.

   ## Changes Made
   - Enabled `navigation.footer` feature in Material theme configuration
   - Added navigation buttons at bottom of documentation pages across all config files
   - Buttons automatically show previous/next page titles and links

   ## Testing
   - [x] Tested locally with `mkdocs serve`
   - [x] Verified buttons appear on documentation pages
   - [x] Confirmed navigation works correctly between pages
   - [x] Applied changes consistently to all three config files

   Fixes #1540