### PR TITLE
Add navigation buttons to documentation pages

### DIFF
--- a/configs/mkdocs.full.yml
+++ b/configs/mkdocs.full.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share

--- a/configs/mkdocs.minimal.yml
+++ b/configs/mkdocs.minimal.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share

--- a/configs/mkdocs.yml
+++ b/configs/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - search.suggest
     - search.highlight
     - search.share


### PR DESCRIPTION
- Enable navigation.footer feature in Material theme
- Add Previous/Next buttons at bottom of documentation pages
- Improves user experience for sequential reading through docs
- Applied consistently across all three config files

Fixes #1540