### PR TITLE
feature: add mkdocs-macros-plugin

### DIFF
--- a/configs/mkdocs.full.yml
+++ b/configs/mkdocs.full.yml
@@ -118,6 +118,9 @@ plugins:
         "guides/add_mirror_manager.md": "guides/mirror_management/add_mirror_manager.md"
   - tags
   - privacy
+  - macros:
+      include_dir: include
+      render_by_default: false
 extra:
   version:
     provider: mike

--- a/configs/mkdocs.minimal.yml
+++ b/configs/mkdocs.minimal.yml
@@ -90,6 +90,9 @@ plugins:
         "guides/add_mirror_manager.md": "guides/mirror_management/add_mirror_manager.md"
   - tags
   - privacy
+  - macros:
+      include_dir: include
+      render_by_default: false
 extra:
   version:
     provider: mike

--- a/configs/mkdocs.yml
+++ b/configs/mkdocs.yml
@@ -119,6 +119,9 @@ plugins:
   - tags
   - privacy:
       assets_fetch: false
+  - macros:
+      include_dir: include
+      render_by_default: false
 extra:
   version:
     provider: mike

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ mkdocs-redirects
 mkdocs-static-i18n==1.3.0
 babel==2.17.0
 mkdocs-material[imaging]
+mkdocs-macros-plugin
 mkdocs-minify-plugin
 mike
 jieba


### PR DESCRIPTION
This PR adds support for the `mkdocs-macros-plugin` to the Rocky Linux documentation. This is primarily added to support the Testing Team wiki content which heavily depends on content includes that this plugin provides support for.

The `mkdocs.yml` files are modified to add the plugin with `render_by_default: false`. With this configuration this plugin should not affect any pages that don't explicitly declare `render_macros: true` in the YAML header of the file.

When merged this should allow merge of https://github.com/rocky-linux/documentation/pull/3262 in the documentation repo.
